### PR TITLE
Update VPN documentation links to new URL

### DIFF
--- a/content/blogg/2022/2022-08-using-jumphost-for-safespring-apis.md
+++ b/content/blogg/2022/2022-08-using-jumphost-for-safespring-apis.md
@@ -136,5 +136,5 @@ Other options include more full-fledged VPN solutions like
 or [OpenVPN](https://openvpn.net/) which are all a lot simpler to configure than
 traditional protocols like IPSec, GRE, PPTP, etc. If you're going to set up a VPN
 in Safespring Compute anyway the gateway can serve as a jump host has well. We've
-created some [documentation on how to get started](https://docs.safespring.com/new/vpn/) and we also provide an [automated setup of a
+created some [documentation on how to get started](https://docs.safespring.com/compute/vpn/) and we also provide an [automated setup of a
 Wireguard gateway](https://github.com/safespring-community/wireguard-gateway) which can be used for this purpose and more, available here

--- a/content/en/services/compute.md
+++ b/content/en/services/compute.md
@@ -64,7 +64,7 @@ For organizations seeking an even more scalable VPN solution, ZeroTier is an exc
 
 At Safespring, we are proud to offer these advanced VPN capabilities integrated directly into our Compute platform. With just a few clicks, you can configure and deploy a complete VPN solution that supports both WireGuard and ZeroTier, ensuring that your organization always has access to secure and flexible network options.
 
-[Read more in our documentation.](https://docs.safespring.com/new/vpn)
+[Read more in our documentation.](https://docs.safespring.com/compute/vpn/)
 
 {{% /accordion %}}
 {{< accordion-script >}}

--- a/content/tjanster/safespring-compute.md
+++ b/content/tjanster/safespring-compute.md
@@ -80,7 +80,7 @@ För organisationer som söker en ännu mer skalbar VPN-lösning är ZeroTier et
 
 På Safespring är vi stolta över att erbjuda dessa avancerade VPN-möjligheter integrerade direkt i vår Compute-plattform. Med bara några få klick kan du konfigurera och deploya en fullständig VPN-lösning som stöder både WireGuard och ZeroTier, vilket säkerställer att din organisation alltid har tillgång till säkra och flexibla nätverksalternativ.
 
-[Läs mer i vår dokumentation](https://docs.safespring.com/new/vpn).
+[Läs mer i vår dokumentation](https://docs.safespring.com/compute/vpn/).
 
 {{% /accordion %}}
 


### PR DESCRIPTION
Changed references to the VPN documentation in blog and service pages from /new/vpn to /compute/vpn to reflect updated documentation location.

---
name: "Pull request"
about: Merge a pull request

---


## Summary

* Closes #[issue number]
* References jira issue FAC-[issue-number]
* Relates to [link to RT issue]

## Details

-