### PR TITLE
Remove Samurai MDR icon block and comment out timeline chart

### DIFF
--- a/content/en/services/managed-infrastructure.md
+++ b/content/en/services/managed-infrastructure.md
@@ -91,8 +91,6 @@ Simplify database management by adding a managed database to your On-Premise Clo
 Maximize the potential of your machine learning and AI projects by adding a Scalout ML platform to your On-Premise Cloud. This add-on service provides a scalable and flexible platform optimized for handling and deploying machine learning models, making it easier for you to train, predict, and analyze data.
 {{% /accordion %}}
 
-{{< icon-block-horisontal icon="fa-kit fa-ntt" color="#195F8C" text="Cyber Threat Detection and Response" description="When a threat is detected, Samurai MDR takes immediate action to isolate and manage the threat." >}}
-
 ## Support and Availability
 
 This service can be delivered with up to 99.9 percent availability, provided the customer meets our data center specifications and capacity usage requirements. Details are included in the standard contract, which is made available during the sales process. Additionally, the standard support process described in [Safespring’s documentation](https://docs.safespring.com/service/policies) applies.
@@ -137,6 +135,7 @@ Presentation and discussion of Safespring’s current and planned product develo
 
 {{< distance >}}
 
+<!--
 {{< chart >}}
 timeline
     section Week 0
@@ -182,6 +181,6 @@ Delivery Meeting: Prepare status report
            : Review user interface
            : Go through platform functionalities
 {{< /chart >}}
-
+-->
 {{< distance >}}
 {{< accordion-script >}}

--- a/content/tjanster/managed-infrastructure.md
+++ b/content/tjanster/managed-infrastructure.md
@@ -95,8 +95,6 @@ Förenkla databashanteringen genom att lägga till en managerad databas till din
 Maximera potentialen hos dina maskininlärnings- och AI-projekt genom att lägga till en Scalout ML plattform till din On-Premise Cloud. Den här tilläggstjänsten ger dig en skalbar och flexibel plattform som är optimerad för att hantera och distribuera maskininlärningsmodeller, vilket gör det enklare för dig att träna, förutsäga och analysera data.
 {{% /accordion %}}
 
-{{< icon-block-horisontal icon="fa-kit fa-ntt" color="#195F8C" text="Cyberhotdetektion och respons" description="Vid upptäckt av ett hot tar Samurai MDR omedelbara åtgärder för att isolera och hantera hotet." link="https://www.safespring.com/tjanster/samurai/" >}}
-
 ## Support och tillgänglighet
 
 Denna tjänst kan levereras med en tillgänglighet på upp till 99,9 procent under förutsättning att kunden följer våra krav på datacenter-specifikationer och gränser för användning av kapacitet. Detaljer om detta ingår i standardkontraktet som blir känt under försäljningsprocessen.
@@ -142,6 +140,7 @@ Presentation och diskussion kring Safesprings aktuella och planerade produktutve
 
 {{< distance >}}
 
+<!--
 {{< chart >}}
 timeline
     section Vecka 0
@@ -187,6 +186,6 @@ Leveransmöte: Förbereda statusrapport
            : Genomgång av användargränssnitt
            : Genomgång av plattformens funktioner
 {{< /chart >}}
-
+-->
 {{< distance >}}
 {{< accordion-script >}}


### PR DESCRIPTION
Deleted the Samurai MDR icon block from both English and Swedish managed infrastructure service pages. Timeline chart sections are now commented out for both files, likely for future revision or removal.

---
name: "Pull request"
about: Merge a pull request

---


## Summary

* Closes #[issue number]
* References jira issue FAC-[issue-number]
* Relates to [link to RT issue]

## Details

-