### PR TITLE
Adjust grid order for totals card in price calculator

### DIFF
--- a/layouts/partials/paas-price-calculator-v7.html
+++ b/layouts/partials/paas-price-calculator-v7.html
@@ -119,8 +119,10 @@
   #price-calculator .pc-layout { display:grid; gap:16px; align-items:stretch; }
   @media (min-width:900px){
     #price-calculator .pc-layout { grid-template-columns: 1fr 1fr; }
-    #price-calculator #pc-card-totals { grid-row: span 3; }
+    #price-calculator #pc-card-totals { grid-row: span 3; order:0}
   }
+
+  #price-calculator #pc-card-totals { grid-row: span 3; order:99;}
 
   /* Cards & inputs */
   #price-calculator .pc-card{ background:#fff; border:1px solid var(--line); border-radius:16px; padding:14px; display:grid; gap:12px; }


### PR DESCRIPTION
Updated the CSS for #pc-card-totals to set its grid order to 99 by default and 0 for screens wider than 900px. This change improves layout control and card positioning in the price calculator component.

---
name: "Pull request"
about: Merge a pull request

---


## Summary

* Closes #[issue number]
* References jira issue FAC-[issue-number]
* Relates to [link to RT issue]

## Details

-